### PR TITLE
[FIX] start with npm run dev

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -32,5 +32,6 @@ export default defineConfig({
         }
       ]
     }),
-  ]
+  ],
+  optimizeDeps: { exclude: ['lila-stockfish-web'] },
 });


### PR DESCRIPTION
Resolve the problem
```
The file does not exist at "C:/.../lila-stockfish-web-example/node_modules/.vite/deps/sf17-79.js?worker_file&type=module" which is in the optimize deps directory. The dependency might be 
incompatible with the dep optimizer. Try adding it to `optimizeDeps.exclude`.
```
when trying to run it with npm run dev to have hot reload.